### PR TITLE
Returning result of parent call from AbstractRecurrent.type()

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -155,10 +155,9 @@ function AbstractRecurrent:includingSharedClones(f)
 end
 
 function AbstractRecurrent:type(type, tensorcache)
-   self:includingSharedClones(function()
+   return self:includingSharedClones(function()
       return parent.type(self, type, tensorcache)
    end)
-   return self
 end
 
 function AbstractRecurrent:training()


### PR DESCRIPTION
Calling `nn.Module.type()` with no arguments returns the type of the module as a string instead of a reference to the module itself. This change makes `nn.AbstractRecurrent` also conform to this API by returning the result of the parent call.
